### PR TITLE
Fix up AWS create_vpc tagging

### DIFF
--- a/engines/aws/app/models/aws/cli.rb
+++ b/engines/aws/app/models/aws/cli.rb
@@ -50,11 +50,11 @@ module Aws
     end
 
     def create_vpc(cidr_block='192.168.0.0/16', vpc_name='curated-installer-vpc')
-      tag = "ResourceType=vpc, Tags=[{Key=Name,Value=#{vpc_name}}]"
+      tag = "ResourceType=vpc,Tags=[{Key=Name,Value=\"#{vpc_name}\"}]"
       args = %W(
-      ec2 create-vpc
-      --cidr-block #{cidr_block}
-      --tag-specifications "#{tag}"
+        ec2 create-vpc
+        --cidr-block #{cidr_block}
+        --tag-specifications #{tag}
       )
       stdout, stderr = execute(*args)
       return stderr if stderr.present?


### PR DESCRIPTION
The spaces and quoting were causing issues; the format submitted here is directly from the documentation[1]

[1] Example 4 https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/create-vpc.html