### PR TITLE
Move steps out of VPC to Deployment (SRP, trackability)

### DIFF
--- a/engines/aws/app/models/aws/allocation_address.rb
+++ b/engines/aws/app/models/aws/allocation_address.rb
@@ -2,33 +2,33 @@ require 'json'
 
 module Aws
   class AllocationAddress < Resource
+    after_initialize :set_cli
     before_create :aws_create_allocation_address
     before_destroy :aws_delete_allocation_address
 
     attr_accessor :subnet_id
 
     def refresh
-      @cli ||= Aws::Cli.load
       self.framework_raw_response = @cli.describe_allocation_addresses
       @response = JSON.parse(self.framework_raw_response)
     end
 
     private
 
+    def set_cli
+      @cli = Aws::Cli.load
+    end
+
     def aws_create_allocation_address
       self.engine = 'Aws'
 
-      @cli ||= Aws::Cli.load
-
       self.framework_raw_response = @cli.allocate_address
-      puts self.framework_raw_response
       @response = JSON.parse(self.framework_raw_response)
       self.id = @response['AllocationId']
     end
 
     def aws_delete_allocation_address
-      @cli ||= Aws::Cli.load
-      @cli.delete_subnet(self.id)
+      @cli.release_address(self.id)
     end
   end
 end

--- a/engines/aws/app/models/aws/internet_gateway.rb
+++ b/engines/aws/app/models/aws/internet_gateway.rb
@@ -2,23 +2,25 @@ require 'json'
 
 module Aws
   class InternetGateway < Resource
+    after_initialize :set_cli
     before_create :aws_create_internet_gateway
     before_destroy :aws_delete_internet_gateway
 
     attr_accessor :vpc_id
 
     def refresh
-      @cli ||= Aws::Cli.load
-      self.framework_raw_response = @cli.describe_internet_gateways(vpc_id)
-      @response = JSON.parse(self.framework_raw_response)
+      self.framework_raw_response = @cli.describe_internet_gateway(self.id)
+      @response = JSON.parse(self.framework_raw_response)['InternetGateways'].first
     end
 
     private
 
+    def set_cli
+      @cli = Aws::Cli.load
+    end
+
     def aws_create_internet_gateway
       self.engine = 'Aws'
-
-      @cli ||= Aws::Cli.load
 
       self.framework_raw_response = @cli.create_internet_gateway
       @response = JSON.parse(self.framework_raw_response)
@@ -27,7 +29,10 @@ module Aws
     end
 
     def aws_delete_internet_gateway
-      @cli ||= Aws::Cli.load
+      self.refresh()
+      @response['Attachments'].each do |attachment|
+        @cli.detach_internet_gateway(attachment['VpcId'], self.id)
+      end
       @cli.delete_internet_gateway(self.id)
     end
   end

--- a/engines/aws/app/models/aws/nat_gateway.rb
+++ b/engines/aws/app/models/aws/nat_gateway.rb
@@ -2,36 +2,51 @@ require 'json'
 
 module Aws
   class NatGateway < Resource
+    after_initialize :set_cli
     before_create :aws_create_nat_gateway
     before_destroy :aws_delete_nat_gateway
 
-    attr_accessor :subnet_id
+    attr_accessor :subnet_id, :allocation_address_id
 
     def refresh
-      @cli ||= Aws::Cli.load
-      self.framework_raw_response = @cli.describe_nat_gateways(vpc_id)
+      self.framework_raw_response = @cli.describe_nat_gateway(self.id)
       @response = JSON.parse(self.framework_raw_response)
+    end
+
+    def wait_until(desired_status)
+      status = ''
+      while status != desired_status.to_s
+        logger.info "waiting for NAT gateway to be #{desired_status}..."
+        begin
+          status = JSON.parse(@cli.describe_nat_gateway(self.id))['NatGateways'].first['State']
+          sleep(15) if status != 'available'
+        rescue
+          status = 'nope'
+        end
+      end
+      self
     end
 
     private
 
+    def set_cli
+      @cli = Aws::Cli.load
+    end
+
     def aws_create_nat_gateway
       self.engine = 'Aws'
 
-      @cli ||= Aws::Cli.load
-
-      allocation_address = Aws::AllocationAddress.create
       self.framework_raw_response = @cli.create_nat_gateway(
-        subnet_id,
-        allocation_address.id
+        self.subnet_id,
+        self.allocation_address_id
       )
       @response = JSON.parse(self.framework_raw_response)
       self.id = @response['NatGateway']['NatGatewayId']
     end
 
     def aws_delete_nat_gateway
-      @cli ||= Aws::Cli.load
       @cli.delete_nat_gateway(self.id)
+      self.wait_until(:deleted)
     end
   end
 end

--- a/engines/aws/app/models/aws/subnet.rb
+++ b/engines/aws/app/models/aws/subnet.rb
@@ -2,23 +2,33 @@ require 'json'
 
 module Aws
   class Subnet < Resource
+    after_initialize :set_cli
     before_create :aws_create_subnet
     before_destroy :aws_delete_subnet
 
     attr_accessor :vpc_id, :subnet_type, :index, :zone
 
     def refresh
-      @cli ||= Aws::Cli.load
       self.framework_raw_response = @cli.describe_subnets(self.id)
       @response = JSON.parse(self.framework_raw_response)
     end
 
+    def map_public_ips!
+      @cli.modify_subnet_to_map_public_ips(self.id)
+    end
+
+    def set_route_table!(route_table_id)
+      @cli.associate_route_table(self.id, route_table_id)
+    end
+
     private
+
+    def set_cli
+      @cli = Aws::Cli.load
+    end
 
     def aws_create_subnet
       self.engine = 'Aws'
-
-      @cli ||= Aws::Cli.load
 
       self.framework_raw_response = @cli.create_subnet(
         vpc_id, subnet_type, index, zone
@@ -28,7 +38,6 @@ module Aws
     end
 
     def aws_delete_subnet
-      @cli ||= Aws::Cli.load
       @cli.delete_subnet(self.id)
     end
   end

--- a/engines/aws/app/models/aws/vpc.rb
+++ b/engines/aws/app/models/aws/vpc.rb
@@ -2,83 +2,30 @@ require 'json'
 
 module Aws
   class Vpc < Resource
+    after_initialize :set_cli
     before_create :aws_create_vpc
     before_destroy :aws_delete_vpc
 
     def refresh
-      @cli ||= Aws::Cli.load
       self.framework_raw_response = @cli.describe_vpc(self.id)
       @response = JSON.parse(self.framework_raw_response)
     end
 
     private
 
+    def set_cli
+      @cli = Aws::Cli.load
+    end
+
     def aws_create_vpc
       self.engine = 'Aws'
 
-      @cli ||= Aws::Cli.load
       self.framework_raw_response = @cli.create_vpc
       @response = JSON.parse(self.framework_raw_response)
       self.id = @response['Vpc']['VpcId']
-
-      availability_zones = @cli.get_availability_zones
-      # if there is an error, return the error
-      return availability_zones unless availability_zones.kind_of?(Array)
-
-      public_route_table = Aws::RouteTable.create(
-        vpc_id: self.id,
-        tag: "curated-installer/public-route-table"
-      )
-      private_route_table_ids = []
-      # create subnets and private route tables
-      availability_zones.each_with_index do |zone, index|
-        public_subnet = Aws::Subnet.create(
-          vpc_id: self.id,
-          subnet_type: 'public',
-          index: index,
-          zone: zone
-        )
-        private_subnet = Aws::Subnet.create(
-          vpc_id: self.id,
-          subnet_type: 'private',
-          index: index,
-          zone: zone
-        )
-        private_route_table = Aws::RouteTable.create(
-          vpc_id: self.id,
-          tag: "curated-installer/private-route-table-#{zone}"
-        )
-        @cli.modify_subnet_attribute(public_subnet.id)
-        @cli.associate_route_table(private_subnet.id, private_route_table.id)
-        @cli.associate_route_table(public_subnet.id, public_route_table.id)
-        private_route_table_ids << private_route_table.id
-      end
-      @igw = Aws::InternetGateway.create(vpc_id: self.id)
-      raw_describe_subnets_response = @cli.describe_subnets(self.id)
-      subnets = JSON.parse(raw_describe_subnets_response)
-      subnet_id = ''
-      subnets['Subnets'].each do |subnet|
-        subnet_id = subnet['SubnetId'] if subnet['CidrBlock'] == '192.168.0.0/19'
-      end
-      @nat_gw = Aws::NatGateway.create(subnet_id: subnet_id)
-      status = ''
-      while status != 'available'
-        sleep(60) # NAT gateway is not active yet, wait 60 seconds
-        puts "waiting (60 seconds) for NAT gateway to be available"
-        describe_nat_response = @cli.describe_nat_gateways(self.id)
-        describe_nat_response = JSON.parse(describe_nat_response)
-        describe_nat_response['NatGateways'].each do |nat|
-          status = nat['State']
-        end
-      end
-      private_route_table_ids.each do |private_route_table_id|
-        @cli.create_route(private_route_table_id, @nat_gw.id)
-      end
-      @cli.create_route(public_route_table.id, @igw.id)
     end
 
     def aws_delete_vpc
-      @cli ||= Aws::Cli.load
       @cli.delete_vpc(self.id)
     end
   end

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
@@ -10,7 +10,8 @@ module RancherOnEks
     end
 
     def deploy
-      RancherOnEks::DeployerJob.perform_later(wait: 1.second)
+      @steps.find_by_rank(0).start!
+      RancherOnEks::DeployerJob.perform_later()
       redirect_to rancher_on_eks.steps_path
     end
 

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/cluster_size.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/cluster_size.rb
@@ -1,0 +1,20 @@
+module RancherOnEks
+  # Defines the specifics of the cluster based on t-shirt size
+  class ClusterSize
+    attr_reader :size
+
+    TYPES_FOR_SIZE = {
+      small: 'm5a.large',
+      medium: 'm5a.xlarge',
+      large: 'm5a.2xlarge'
+    }
+
+    def initialize(*args)
+      @size = KeyValue.get('cluster_size', 'small')
+    end
+
+    def instance_type
+      TYPES_FOR_SIZE[@size.to_sym]
+    end
+  end
+end

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/deployment.rb
@@ -2,47 +2,181 @@ module RancherOnEks
   class Deployment
     def create_steps!
       KeyValue.set('tag_scope', 'ranchers-spouse')
-
+      Step.create!(
+        rank: 0,
+        action: 'Prep'
+      )
       Step.create!(
         rank: 1,
         action: 'Create a VPC'
       )
+
+      index = 1
+      (2..4).each do |rank|
+        Step.create!(
+          rank: rank,
+          action: "Create public subnet #{index}/3"
+        )
+        index += 1
+      end
+
       Step.create!(
-        rank: 2,
-        action: 'Create a Cluster'
+        rank: 5,
+        action: 'Create an Internet Gateway for public subnets'
       )
       Step.create!(
-        rank: 3,
+        rank: 6,
+        action: 'Route public subnets through Internet Gateway'
+      )
+
+      index = 1
+      (7..9).each do |rank|
+        Step.create!(
+          rank: rank,
+          action: "Create private subnet #{index}/3"
+        )
+        index += 1
+      end
+
+      Step.create!(
+        rank: 10,
+        action: 'Secure an Elastic IP address'
+      )
+      Step.create!(
+        rank: 11,
+        action: 'Create a NAT Gateway for private subnets on Elastic IP address'
+      )
+
+      index = 1
+      (12..14).each do |rank|
+        Step.create!(
+          rank: rank,
+          action: "Route private subnet #{index}/3 through NAT Gateway"
+        )
+        index += 1
+      end
+      Step.create!(
+        rank: 15,
+        action: 'Create a Cluster'
+      )
+      Step.create
+        rank: 16,
         action: 'Create a Node Group'
       )
       Step.create!(
-        rank: 4,
+        rank: 17,
         action: 'Deploy Rancher'
       )
     end
 
     def step(rank)
       step = Step.find_by(rank: rank)
+      return if step.complete?
       step.start!
-      step.resource = yield
+      step.resource = yield if block_given?
       step.save
       step.complete!
     end
 
     def deploy
-      step(1) do
-        @vpc = Aws::Vpc.create
-      end
-      step(2) do
-        @cluster = Aws::Cluster.create(vpc_id: @vpc.id)
-      end
-      step(3) do
-        Aws::NodeGroup.create(vpc_id: @vpc.id, cluster_name: @cluster.id)
-      end
-      step(4) do
-        Helm::Deployment.create
+      step(0) do
+        @cluster_size = RancherOnEks::ClusterSize.new
+        @cli = Aws::Cli.load
+
+        zones = @cli.list_availability_zones_supporting_instance_type(
+          @cluster_size.instance_type
+        )
+        if zones.length >= 3
+          @zones = zones.sample(3)
+        else
+          # if we have less than 3 AZ choices, set up multiple subnets in the
+          # same AZ, randomly selected
+          @zones = zones
+          while @zones.length < 3
+            @zones << zones.sample()
+          end
+        end
       end
 
+      step(1) do
+        @vpc = Aws::Vpc.create()
+      end
+
+      @public_subnets = []
+      index = 0
+      (2..4).each do |rank|
+        step(rank) do
+          public_subnet = Aws::Subnet.create(
+            vpc_id: @vpc.id,
+            subnet_type: 'public',
+            index: index,
+            zone: @zones[index]
+          )
+          public_subnet.map_public_ips!
+          @public_subnets << public_subnet
+          index += 1
+          public_subnet
+        end
+      end
+      step(5) do
+        @gateway = Aws::InternetGateway.create(vpc_id: @vpc.id)
+        @gateway
+      end
+      step(6) do
+        @public_route_table = Aws::RouteTable.create(vpc_id: @vpc.id)
+        @cli.create_route(@public_route_table.id, @gateway.id)
+        @public_subnets.each do |public_subnet|
+          public_subnet.set_route_table!(@public_route_table.id)
+        end
+        @public_route_table
+      end
+
+      @private_subnets = []
+      index = 0
+      (7..9).each do |rank|
+        step(rank) do
+          private_subnet = Aws::Subnet.create(
+            vpc_id: @vpc.id,
+            subnet_type: 'private',
+            index: index,
+            zone: @zones[index]
+          )
+          @private_subnets << private_subnet
+          index += 1
+          private_subnet
+        end
+      end
+      step(10) do
+        @elastic_ip = Aws::AllocationAddress.create()
+      end
+      step(11) do
+        @nat = Aws::NatGateway.create(
+          subnet_id: @public_subnets.first.id,
+          allocation_address_id: @elastic_ip.id
+        )
+        @nat.wait_until(:available)
+      end
+      @private_route_tables = []
+      index = 0
+      (12..14).each do |rank|
+        step(rank) do
+          private_subnet = @private_subnets[index]
+          private_route_table = Aws::RouteTable.create(vpc_id: @vpc.id, name: "private-route-table-#{index}")
+          private_subnet.set_route_table!(private_route_table.id)
+          @private_route_tables << private_route_table
+          index += 1
+          private_route_table
+        end
+      end
+      step(15) do
+        @cluster = Aws::Cluster.create(vpc_id: @vpc.id)
+      end
+      step(16) do
+        Aws::NodeGroup.create(vpc_id: @vpc.id, cluster_name: @cluster.id)
+      end
+      step(17) do
+        Helm::Deployment.create
+      end
     end
   end
 end

--- a/engines/rancher_on_eks/app/views/rancher_on_eks/steps/index.html.haml
+++ b/engines/rancher_on_eks/app/views/rancher_on_eks/steps/index.html.haml
@@ -10,16 +10,13 @@
           - if step.complete?
             %i.eos-icons-outlined check_circle
           - elsif step.started?
-            = image_tag 'rotating_gear.svg', alt: 'working...', height: 24
+            %i.eos-icons-outlined
+              = image_tag 'rotating_gear.svg', alt: 'working...'
           - else
             %i.eos-icons-outlined lens
           = step.rank
           \.
           = step.action
-          - if step.resource_id.present?
-            [
-            %span.text-monospace= step.resource_id
-            ]
     %div.col-6
       %ul
         - @resources.each do |resource|


### PR DESCRIPTION
The VPC Class was no longer just managing the VPC, but all of the dependent objects. This violated SRP, and overloaded the VPC, preventing it from even saving the ID if any dependent object failed.

With the steps broken out to the deployment (as steps), we can more accurately pinpoint errors and handle them.