### PR TITLE
Show a progress bar for deployment

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,18 @@
  *= require_self
  */
 
- .alert-section .alert-title {
-   margin-top: 4px;
- }
+.alert-section .alert-title {
+  margin-top: 4px;
+}
+
+.progress-bar .step.complete {
+  background-color: #0e7e3c;
+}
+
+.progress-bar .step.started {
+  background-color: #30BA78;
+}
+
+.progress-bar .step.todo {
+  background-color: #E4F6EE;
+}

--- a/db/migrate/20220324022910_add_duration_to_step.rb
+++ b/db/migrate/20220324022910_add_duration_to_step.rb
@@ -1,0 +1,5 @@
+class AddDurationToStep < ActiveRecord::Migration[7.0]
+  def change
+    add_column :steps, :duration, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_07_190704) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_24_022910) do
   create_table "key_values", force: :cascade do |t|
     t.string "key", null: false
     t.text "value"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_07_190704) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "duration", default: 1
     t.index ["rank"], name: "index_steps_on_rank", unique: true
   end
 

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/steps_controller.rb
@@ -5,8 +5,9 @@ module RancherOnEks
     def index
       @deployable = Step.deployable?
       @complete = Step.all_complete?
-      @refresh_timer = 10 unless (@deployable || @complete)
-      @resources = Resource.all
+      redirect_to rancher_on_eks.wrapup_path if @complete
+
+      @refresh_timer = 15 unless (@deployable || @complete)
     end
 
     def deploy

--- a/engines/rancher_on_eks/app/views/rancher_on_eks/steps/index.html.haml
+++ b/engines/rancher_on_eks/app/views/rancher_on_eks/steps/index.html.haml
@@ -2,27 +2,25 @@
 -# body
 %p
   %strong= t('engines.rancher_on_eks.steps.form_caption')
+-# progress bar
 %div.container
-  %div.row
-    %div.col-6
-      - @steps.each do |step|
-        %p.icon-container
-          - if step.complete?
-            %i.eos-icons-outlined check_circle
-          - elsif step.started?
-            %i.eos-icons-outlined
-              = image_tag 'rotating_gear.svg', alt: 'working...'
-          - else
-            %i.eos-icons-outlined lens
-          = step.rank
-          \.
-          = step.action
-    %div.col-6
-      %ul
-        - @resources.each do |resource|
-          %li
-            = resource.type
-            = resource.id
+  %div.d-flex.flex-row.border.border-dark.progress-bar
+    - @steps.each do |step|
+      - if step.complete?
+        - status = "complete"
+      - elsif step.started?
+        - status = "started"
+      - else
+        - status = "todo"
+      %div.p-2.step{class: status, style: "flex-grow: #{step.duration};", title: "#{step.rank}. #{step.action}", data: {toggle: "tooltip", placement: "bottom"}}
+  - @steps.each do |step|
+    - if step.started? && !step.complete?
+      %p.icon-container
+        %i.eos-icons-outlined
+          = image_tag 'rotating_gear.svg', alt: 'working...'
+        = step.rank
+        \.
+        = step.action
 - if @deployable
   = form_with url: rancher_on_eks.deploy_steps_path, method: 'post' do |form|
     %div.form-group


### PR DESCRIPTION
Steps are represented as proportional-width sections of the bar, based on times established through repeated deployments.

The current step's text is listed while in progress. When complete, the user is redirected to the wrapup page.

![Screenshot 2022-03-23 at 22-28-16 SUSE Lasso](https://user-images.githubusercontent.com/108494/159849275-7cf06b62-c5e4-4c48-9ad9-6b0e8916cfa2.png)

