### PR TITLE
Require username and password

### DIFF
--- a/packaging/curated-cloud-installer.spec
+++ b/packaging/curated-cloud-installer.spec
@@ -39,6 +39,7 @@ Requires:       %{ruby_version}
 Requires:       %{k8s_version}-client
 Requires:       helm
 Requires:       nginx
+Requires:       python3-cloudinstancecredentials
 # Does not build for i586, s390, aarch64 and is not supported on those architectures
 ExcludeArch:    %{ix86} s390 aarch64
 

--- a/server-configs/nginx/curated-cloud-installer.conf
+++ b/server-configs/nginx/curated-cloud-installer.conf
@@ -3,6 +3,8 @@ upstream app {
 }
 
 server {
+    auth_basic	         'Authorization required';
+    auth_basic_user_file /etc/nginx/cloudinstancecredentials;
     listen 80 default;
     listen [::]:80 default;
     server_name curated-cloud-installer;


### PR DESCRIPTION
- Require username and password to access
  the wizard

- In this case, the username is instance-id and
  password is account-id
- Add python3-cloudinstancecredentials package

This Fixes #25