### PR TITLE
Remove FQDN URL validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,5 +39,4 @@ en:
 
   flash:
     invalid_credentials: "Credentials are not valid."
-    invalid_url: "URL is not valid: "
     no_hosted_zone: "The subdomain is not a route 53 hosted zone: "

--- a/engines/rancher_on_eks/app/controllers/rancher_on_eks/fqdn_controller.rb
+++ b/engines/rancher_on_eks/app/controllers/rancher_on_eks/fqdn_controller.rb
@@ -7,14 +7,11 @@ module RancherOnEks
     def update
       @fqdn = Fqdn.new(self.fqdn_params)
       hosted_zone = @fqdn.subdomain_hosted_zone?
-      valid_url = @fqdn.valid_url?
-      if valid_url && hosted_zone && @fqdn.save
+      if hosted_zone && @fqdn.save
         flash[:success] = t('engines.rancher_on_eks.fqdn.using', fqdn: @fqdn.value)
         redirect_to(helpers.next_step_path(rancher_on_eks.edit_fqdn_path))
       else
-        if !valid_url
-          flash[:warning] = t('flash.invalid_url') + "https://#{@fqdn.value}."
-        elsif !hosted_zone
+        if !hosted_zone
           flash[:warning] = t('flash.no_hosted_zone') + "#{@fqdn.value}."
         else
           flash[:warning] = @fqdn.errors.full_messages

--- a/engines/rancher_on_eks/app/models/rancher_on_eks/fqdn.rb
+++ b/engines/rancher_on_eks/app/models/rancher_on_eks/fqdn.rb
@@ -24,12 +24,5 @@ module RancherOnEks
     rescue
       false
     end
-
-    def valid_url?
-      status = URI.open("https://#{@value}").status
-      status.include? 'OK'
-    rescue
-      false
-    end
   end
 end


### PR DESCRIPTION
- Because of the different ways the FQDN can be set up,
  dropping its validation for the time being